### PR TITLE
feat(events): Emit k8s event when deleting SpinAppExecutor is blocked because of dependent SpinApps

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -102,15 +102,17 @@ func main() {
 	}
 
 	if err = (&controller.SpinAppReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("spinapp-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SpinApp")
 		os.Exit(1)
 	}
 	if err = (&controller.SpinAppExecutorReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("spinappexecutor-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SpinAppExecutor")
 		os.Exit(1)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -35,6 +35,13 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - core.spinoperator.dev
   resources:
   - spinappexecutors

--- a/internal/controller/spinapp_controller.go
+++ b/internal/controller/spinapp_controller.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -49,8 +50,9 @@ const (
 
 // SpinAppReconciler reconciles a SpinApp object
 type SpinAppReconciler struct {
-	Client client.Client
-	Scheme *runtime.Scheme
+	Client   client.Client
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
 }
 
 //+kubebuilder:rbac:groups=core.spinoperator.dev,resources=spinapps,verbs=get;list;watch;create;update;patch;delete
@@ -58,6 +60,7 @@ type SpinAppReconciler struct {
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SpinAppReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/spinapp_controller_test.go
+++ b/internal/controller/spinapp_controller_test.go
@@ -70,29 +70,30 @@ func SetupEnvTest(t *testing.T) *envTestState {
 	}
 }
 
-func TestReconcile_Integration_StartupShutdown(t *testing.T) {
+func TestSpinAppReconcilerStartupShutdown(t *testing.T) {
 	t.Parallel()
 
 	envTest := SetupEnvTest(t)
-
-	ctrlr := &SpinAppReconciler{
-		Client: envTest.k8sClient,
-		Scheme: scheme.Scheme,
-	}
 
 	mgr, err := ctrl.NewManager(envTest.cfg, manager.Options{
 		Metrics: metricsserver.Options{BindAddress: "0"},
 	})
 	require.NoError(t, err)
 
-	require.NoError(t, ctrlr.SetupWithManager(mgr))
+	reconciler := &SpinAppReconciler{
+		Client:   envTest.k8sClient,
+		Scheme:   scheme.Scheme,
+		Recorder: mgr.GetEventRecorderFor("spinapp-controller"),
+	}
+
+	require.NoError(t, reconciler.SetupWithManager(mgr))
 
 	ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelFunc()
 	require.NoError(t, mgr.Start(ctx))
 }
 
-func TestConstructDeployment_MinimalApp(t *testing.T) {
+func TestConstructDeploymentMinimalApp(t *testing.T) {
 	t.Parallel()
 
 	app := minimalSpinApp()


### PR DESCRIPTION
We'll need to add more events then just this one, but this sets up the scaffolding and is a start.

DO NOT MERGE: I can't get the integration tests to work yet.