### PR TITLE
nit: prefer `kubectl create` over `kubectl apply`

### DIFF
--- a/.github/workflows/helm-install-smoketest.yaml
+++ b/.github/workflows/helm-install-smoketest.yaml
@@ -75,7 +75,7 @@ jobs:
 
       - name: run spin app
         run: |
-          kubectl apply -f config/samples/simple.yaml
+          kubectl create -f config/samples/simple.yaml
           kubectl rollout status deployment simple-spinapp --timeout 90s
           kubectl get pods -A
           kubectl port-forward svc/simple-spinapp 8083:80 &

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -30,7 +30,7 @@ jobs:
           --agents 2
 
       - name: apply runtime class
-        run: kubectl apply -f config/samples/spin-runtime-class.yaml
+        run: kubectl create -f config/samples/spin-runtime-class.yaml
 
       - name: start controller
         timeout-minutes: 5
@@ -44,8 +44,8 @@ jobs:
 
       - name: run spin app
         run: |
-          kubectl apply -f config/samples/spin-shim-executor.yaml
-          kubectl apply -f config/samples/simple.yaml
+          kubectl create -f config/samples/spin-shim-executor.yaml
+          kubectl create -f config/samples/simple.yaml
           kubectl rollout status deployment simple-spinapp --timeout 90s
 
           kubectl port-forward svc/simple-spinapp 8083:80 &


### PR DESCRIPTION
this forces the client to return a non-zero exit code if the resource already exists. This should be the preferred method for most situations to ensure we don't accidentally change resources in a prod context.

Are there situations where `kubectl apply` is preferred? e.g. in the Makefile during development?