### PR TITLE
Reference `cpu-load-gen` image from ghcr.io

### DIFF
--- a/config/samples/hpa.yaml
+++ b/config/samples/hpa.yaml
@@ -3,8 +3,7 @@ kind: SpinApp
 metadata:
   name: hpa-spinapp
 spec:
-  # TODO: Depend on a ghcr.io version of this image
-  image: "ttl.sh/cpu-load-gen:1h"
+  image: ghcr.io/spinkube/spin-operator/cpu-load-gen:20240311-163328-g1121986
   executor: containerd-shim-spin
   enableAutoscaling: true
   resources:

--- a/config/samples/keda-app.yaml
+++ b/config/samples/keda-app.yaml
@@ -3,8 +3,7 @@ kind: SpinApp
 metadata:
   name: keda-spinapp
 spec:
-  # TODO: Depend on a ghcr.io version of this image
-  image: "ttl.sh/cpu-load-gen:1h"
+  image: ghcr.io/spinkube/spin-operator/cpu-load-gen:20240311-163328-g1121986
   executor: containerd-shim-spin
   enableAutoscaling: true
   replicas: 1


### PR DESCRIPTION
With this commit samples for HPA and KEDA will pull Spin App images from ghcr.io instead of ttl.sh