### PR TITLE
fix(samples): rm replicas config from keda-app

### DIFF
--- a/config/samples/keda-app.yaml
+++ b/config/samples/keda-app.yaml
@@ -6,7 +6,6 @@ spec:
   image: ghcr.io/spinkube/spin-operator/cpu-load-gen:20240311-163328-g1121986
   executor: containerd-shim-spin
   enableAutoscaling: true
-  replicas: 1
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
Remove the `replicas` configuration per operator error:
```
$ k apply -f config/samples/keda-app.yaml
The SpinApp "keda-spinapp" is invalid: spec.replicas: Invalid value: 1: replicas cannot be set when autoscaling is enabled
```