### PR TITLE
ci(sample-apps.yaml): use github.repository_owner in references

### DIFF
--- a/.github/workflows/sample-apps.yaml
+++ b/.github/workflows/sample-apps.yaml
@@ -38,5 +38,5 @@ jobs:
             registry: ${{ env.REGISTRY }}
             registry_username: ${{ github.actor }}
             registry_password: ${{ secrets.GITHUB_TOKEN }}
-            registry_reference: "ghcr.io/spinkube/spin-operator/${{ matrix.app }}:${{ env.RELEASE_VERSION }}"
+            registry_reference: "ghcr.io/${{ github.repository_owner }}/spin-operator/${{ matrix.app }}:${{ env.RELEASE_VERSION }}"
             manifest_file: apps/${{ matrix.app }}/spin.toml


### PR DESCRIPTION
- Update sample app references to use `github.repository_owner`

This is handy for forks that test CI/CD and/or would otherwise like to publish sample apps to their fork.