### PR TITLE
ci(publish.yaml): add step summary with artifact references

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -129,6 +129,13 @@ jobs:
       - name: Publish chart
         run: make helm-publish
 
+      - name: Artifact summary - ${{ env.RELEASE_VERSION }}
+        run: |
+          echo '### Spin Operator artifacts published:' >> $GITHUB_STEP_SUMMARY
+          echo '- `Docker image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.APP_VERSION }}`' >> $GITHUB_STEP_SUMMARY
+          echo '- `Helm chart reference: ${{ env.CHART_REGISTRY }}/spin-operator`' >> $GITHUB_STEP_SUMMARY
+          echo '- `Helm chart version: ${{ env.CHART_VERSION }}`' >> $GITHUB_STEP_SUMMARY
+
   release:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
- Add a published artifacts summary to the `publish.yaml` workflow, eg

<img width="668" alt="Screenshot 2024-03-12 at 3 34 34 PM" src="https://github.com/spinkube/spin-operator/assets/9322017/b13e6843-153c-45b5-8baf-2dc05c9cc100">
