### PR TITLE
fix(spin/certs): inject CA bunde in the filesystem

### DIFF
--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -52,14 +52,14 @@ func TestConstructVolumeMountsForApp_Contract(t *testing.T) {
 	// places.
 	app := minimalSpinApp()
 	app.Spec.RuntimeConfig.LoadFromSecret = "a-secret"
-	_, _, err := ConstructVolumeMountsForApp(context.Background(), app, "a-generated-secret")
+	_, _, err := ConstructVolumeMountsForApp(context.Background(), app, "a-generated-secret", "a-ca-secret")
 	require.Error(t, err)
 	require.ErrorContains(t, err, "cannot specify both a user-provided runtime secret and a generated one")
 
 	// No runtime secret at all is ok
 	app = minimalSpinApp()
 	app.Spec.RuntimeConfig.LoadFromSecret = ""
-	volumes, mounts, err := ConstructVolumeMountsForApp(context.Background(), app, "")
+	volumes, mounts, err := ConstructVolumeMountsForApp(context.Background(), app, "", "")
 	require.NoError(t, err)
 	require.Empty(t, volumes)
 	require.Empty(t, mounts)
@@ -67,7 +67,7 @@ func TestConstructVolumeMountsForApp_Contract(t *testing.T) {
 	// User provided runtime secret is ok
 	app = minimalSpinApp()
 	app.Spec.RuntimeConfig.LoadFromSecret = "foo-secret-v1"
-	volumes, mounts, err = ConstructVolumeMountsForApp(context.Background(), app, "")
+	volumes, mounts, err = ConstructVolumeMountsForApp(context.Background(), app, "", "")
 	require.NoError(t, err)
 	require.Len(t, volumes, 1)
 	require.Len(t, mounts, 1)
@@ -76,7 +76,7 @@ func TestConstructVolumeMountsForApp_Contract(t *testing.T) {
 	// Generated runtime secret is ok
 	app = minimalSpinApp()
 	app.Spec.RuntimeConfig.LoadFromSecret = ""
-	volumes, mounts, err = ConstructVolumeMountsForApp(context.Background(), app, "gen-secret")
+	volumes, mounts, err = ConstructVolumeMountsForApp(context.Background(), app, "gen-secret", "spin-ca")
 	require.NoError(t, err)
 	require.Len(t, volumes, 1)
 	require.Len(t, mounts, 1)
@@ -227,7 +227,7 @@ func TestSpinHealthCheckToCoreProbe(t *testing.T) {
 func TestDeploymentLabel(t *testing.T) {
 	scheme := registerAndGetScheme()
 	app := minimalSpinApp()
-	deployment, err := constructDeployment(context.Background(), app, &spinv1alpha1.ExecutorDeploymentConfig{}, "", scheme)
+	deployment, err := constructDeployment(context.Background(), app, &spinv1alpha1.ExecutorDeploymentConfig{}, "", "", scheme)
 
 	require.Nil(t, err)
 	require.NotNil(t, deployment.ObjectMeta.Labels)

--- a/internal/controller/spinapp_controller.go
+++ b/internal/controller/spinapp_controller.go
@@ -279,7 +279,10 @@ func (r *SpinAppReconciler) reconcileDeployment(ctx context.Context, app *spinv1
 		}
 	}
 
-	desiredDeployment, err := constructDeployment(ctx, app, config, generatedRuntimeConfigSecretName, r.Scheme)
+	// TODO: make this configurable
+	caSecretName := "spin-ca"
+
+	desiredDeployment, err := constructDeployment(ctx, app, config, generatedRuntimeConfigSecretName, caSecretName, r.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to construct Deployment: %w", err)
 	}
@@ -346,7 +349,7 @@ func (r *SpinAppReconciler) deleteDeployment(ctx context.Context, app *spinv1alp
 
 // constructDeployment builds an appsv1.Deployment based on the configuration of a SpinApp.
 func constructDeployment(ctx context.Context, app *spinv1alpha1.SpinApp, config *spinv1alpha1.ExecutorDeploymentConfig,
-	generatedRuntimeConfigSecretName string, scheme *runtime.Scheme) (*appsv1.Deployment, error) {
+	generatedRuntimeConfigSecretName string, caSecretName string, scheme *runtime.Scheme) (*appsv1.Deployment, error) {
 	// TODO: Once we land admission webhooks write some validation to make
 	// replicas and enableAutoscaling mutually exclusive.
 	var replicas *int32
@@ -356,7 +359,7 @@ func constructDeployment(ctx context.Context, app *spinv1alpha1.SpinApp, config 
 		replicas = ptr(app.Spec.Replicas)
 	}
 
-	volumes, volumeMounts, err := ConstructVolumeMountsForApp(ctx, app, generatedRuntimeConfigSecretName)
+	volumes, volumeMounts, err := ConstructVolumeMountsForApp(ctx, app, generatedRuntimeConfigSecretName, caSecretName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/spinapp_controller_test.go
+++ b/internal/controller/spinapp_controller_test.go
@@ -402,7 +402,7 @@ func TestConstructDeployment_MinimalApp(t *testing.T) {
 	cfg := &spinv1alpha1.ExecutorDeploymentConfig{
 		RuntimeClassName: "bananarama",
 	}
-	deployment, err := constructDeployment(context.Background(), app, cfg, "", nil)
+	deployment, err := constructDeployment(context.Background(), app, cfg, "", "", nil)
 	require.NoError(t, err)
 	require.NotNil(t, deployment)
 


### PR DESCRIPTION
In https://github.com/spinkube/containerd-shim-spin/issues/44 and https://github.com/deislabs/containerd-wasm-shims/issues/176, a Spin application cannot make a TLS connection because the file system the host component is running in does not have a CA bundle.

To address it, this commit injects a CA bundle in the file system for every application pod created by injecting a default secret into `/etc/ssl/certs/ca-certificates.crt`.

There are a few alternatives to this approach:

* using the node's CA bundle
* compiling the default CA bundle into the shim executing the Spin application
* requiring each application to provide its own bundle

All of those alternatives have the main limitation of tying the bundle to either the app, shim, or node artifact (and all the lifecycle issue arising from that).
In contrast, this allows a cluster admin to configure this (while also allowing us to have a default bundle that works for a majority of use cases out of the box).


I tested this PR with an app that makes TLS connections, and used Alpine's bundle, which is ~215 KB in size.

The main limitation of this approach is having to respect the 1MB secret size of Kubernetes.
(I can see an experience for working around the 1MB size where a cluster admin could create a volume with the CA bundle, and the Spin operator could inject that instead of a (the?) default secret. That is not is scope for this PR.)




To test this draft, you need to fetch a bundle and create a secret from it:

```
# Alpine's bundle pushed to filebin by me.
$ wget https://filebin.net/yc0ako929ozv2slu/ca-certificates.crt
$ kubectl create secret generic spin-ca --from-file=ca-certificates.crt
```

Marking as a draft, as it needs testing and a way to create the secret at deployment time.