### PR TITLE
Add podServiceAccountName to SpinApp CRD

### DIFF
--- a/api/v1alpha1/spinapp_types.go
+++ b/api/v1alpha1/spinapp_types.go
@@ -77,6 +77,9 @@ type SpinAppSpec struct {
 
 	// Resources defines the resource requirements for this app.
 	Resources Resources `json:"resources,omitempty"`
+
+	// ServiceAccountName for the underlying Pod.
+	PodServiceAccountName string `json:"podServiceAccountName,omitempty"`
 }
 
 // SpinAppStatus defines the observed state of SpinApp

--- a/config/crd/bases/core.spinoperator.dev_spinapps.yaml
+++ b/config/crd/bases/core.spinoperator.dev_spinapps.yaml
@@ -237,6 +237,9 @@ spec:
                 description: PodAnnotations defines annotations to be applied to the
                   underlying pods.
                 type: object
+              podServiceAccountName:
+                description: ServiceAccountName for the underlying Pod.
+                type: string
               replicas:
                 description: Number of replicas to run.
                 format: int32

--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -241,3 +241,18 @@ func registerAndGetScheme() *runtime.Scheme {
 
 	return scheme
 }
+
+func spinAppWithPodServiceAccountName(name string) *spinv1alpha1.SpinApp {
+	return &spinv1alpha1.SpinApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-app",
+			Namespace: "default",
+		},
+		Spec: spinv1alpha1.SpinAppSpec{
+			Executor:              "containerd-shim-spin",
+			Image:                 "fakereg.dev/noapp:latest",
+			Replicas:              1,
+			PodServiceAccountName: name,
+		},
+	}
+}

--- a/internal/controller/spinapp_controller.go
+++ b/internal/controller/spinapp_controller.go
@@ -414,7 +414,8 @@ func constructDeployment(ctx context.Context, app *spinv1alpha1.SpinApp, config 
 					Annotations: templateAnnotations,
 				},
 				Spec: corev1.PodSpec{
-					RuntimeClassName: &config.RuntimeClassName,
+					RuntimeClassName:   &config.RuntimeClassName,
+					ServiceAccountName: app.Spec.PodServiceAccountName,
 					Containers: []corev1.Container{
 						{
 							Name:    app.Name,

--- a/internal/controller/spinapp_controller_test.go
+++ b/internal/controller/spinapp_controller_test.go
@@ -411,3 +411,18 @@ func TestConstructDeployment_MinimalApp(t *testing.T) {
 	require.Equal(t, app.Spec.Image, deployment.Spec.Template.Spec.Containers[0].Image)
 	require.Equal(t, ptr("bananarama"), deployment.Spec.Template.Spec.RuntimeClassName)
 }
+
+func TestConstructDeployment_AppWithPodServiceAccountName(t *testing.T) {
+	t.Parallel()
+
+	app := spinAppWithPodServiceAccountName("test")
+
+	cfg := &spinv1alpha1.ExecutorDeploymentConfig{
+		RuntimeClassName: "bananarama",
+	}
+	deployment, err := constructDeployment(context.Background(), app, cfg, "", nil)
+	require.NoError(t, err)
+	require.NotNil(t, deployment)
+
+	require.Equal(t, deployment.Spec.Template.Spec.ServiceAccountName, "test")
+}


### PR DESCRIPTION
With this PR, users are able to specify the `ServiceAccountName` for underlying pods

closes #226