### PR TITLE
Emit k8s event when deleting SpinAppExecutor is blocked because of dependent SpinApps

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -110,8 +110,9 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controller.SpinAppExecutorReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("spinappexecutor-reconciler"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SpinAppExecutor")
 		os.Exit(1)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -47,6 +47,13 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - core.spinoperator.dev
   resources:
   - spinappexecutors

--- a/internal/controller/spinapp_controller.go
+++ b/internal/controller/spinapp_controller.go
@@ -66,6 +66,7 @@ type SpinAppReconciler struct {
 //+kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SpinAppReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/spinappexecutor_controller.go
+++ b/internal/controller/spinappexecutor_controller.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -36,12 +37,14 @@ var (
 // SpinAppExecutorReconciler reconciles a SpinAppExecutor object
 type SpinAppExecutorReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
 }
 
 //+kubebuilder:rbac:groups=core.spinoperator.dev,resources=spinappexecutors,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core.spinoperator.dev,resources=spinappexecutors/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=core.spinoperator.dev,resources=spinappexecutors/finalizers,verbs=update
+//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SpinAppExecutorReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -106,6 +109,7 @@ func (r *SpinAppExecutorReconciler) handleDeletion(ctx context.Context, executor
 	}
 
 	if len(spinApps.Items) > 0 {
+		r.Recorder.Event(executor, "Warning", "DeletionBlocked", "Cannot delete SpinAppExecutor with dependent SpinApps")
 		return errors.New("cannot delete SpinAppExecutor with dependent SpinApps")
 	}
 

--- a/internal/controller/spinappexecutor_controller_test.go
+++ b/internal/controller/spinappexecutor_controller_test.go
@@ -54,8 +54,9 @@ func setupExecutorController(t *testing.T) (*envTestState, ctrl.Manager, *SpinAp
 	require.NoError(t, err)
 
 	ctrlr := &SpinAppExecutorReconciler{
-		Client: envTest.k8sClient,
-		Scheme: envTest.scheme,
+		Client:   envTest.k8sClient,
+		Scheme:   envTest.scheme,
+		Recorder: mgr.GetEventRecorderFor("spinappexecutor-reconciler"),
 	}
 
 	require.NoError(t, ctrlr.SetupWithManager(mgr))


### PR DESCRIPTION
Supersedes #7 