### PR TITLE
spin-ca: Migrate tests from E2E to unit and integration

### DIFF
--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -46,6 +46,20 @@ func TestConstructRuntimeConfigSecretMount_Contract(t *testing.T) {
 	require.Contains(t, mount.Name, "spin-")
 }
 
+func TestConstructCASecretMount(t *testing.T) {
+	t.Parallel()
+
+	volume, mount := constructCASecretMount(context.Background(), "a-secret-name")
+
+	// Mount and Volume refer to each other
+	require.Equal(t, volume.Name, mount.Name)
+
+	// uses provided secret name
+	require.Equal(t, "a-secret-name", volume.Secret.SecretName)
+
+	require.True(t, mount.ReadOnly)
+}
+
 func TestConstructVolumeMountsForApp_Contract(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Our tests for the Spin CA don't validate that the resulting TLS bundle is used by the shim, so migrate the core of the tests to lighterweight integration and unit tests.

A future E2E that installs a bundle and validates outbound-tls would also be excellent.

I've avoided adding net-new tests here (as a refactor), but intend to follow up in a new PR with tests that cover the pre-existing secret cases, alongside drafts of how we may version the CA bundle.