### PR TITLE
tests: skip e2e by default

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
             --junitfile .results/results.xml \
             --jsonfile .results/results.json \
             --format testname \
-            -- -coverprofile=.results/cover.out ./...
+            -- -coverprofile=.results/cover.out $(go list ./... | grep -v e2e)
 
       - name: Test Summary
         uses: test-summary/action@v2

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -race ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -race $(go list ./... | grep -v e2e) -coverprofile cover.out
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.54.2


### PR DESCRIPTION
When we added e2e tests, we split them into a separate job and introduced `make e2e`,  but in the process didn't _exclude_ them from other test execution, which means we've been inadvertently slowing down our build pipelines and development flow (executing e2e's twice when running `make test e2e`).

This PR adds those skips.