### PR TITLE
deployment: Set SPIN_HTTP_LISTEN_ADDR env var

### DIFF
--- a/internal/controller/deployment.go
+++ b/internal/controller/deployment.go
@@ -103,11 +103,7 @@ func ConstructVolumeMountsForApp(ctx context.Context, app *spinv1alpha1.SpinApp,
 
 // ConstructEnvForApp constructs the env for a spin app that runs as a k8s pod.
 // Variables are not guaranteed to stay backed by ENV.
-func ConstructEnvForApp(ctx context.Context, app *spinv1alpha1.SpinApp) []corev1.EnvVar {
-	if len(app.Spec.Variables) == 0 {
-		return nil
-	}
-
+func ConstructEnvForApp(ctx context.Context, app *spinv1alpha1.SpinApp, listenPort int) []corev1.EnvVar {
 	envs := make([]corev1.EnvVar, len(app.Spec.Variables))
 	for idx, variable := range app.Spec.Variables {
 		env := corev1.EnvVar{
@@ -120,6 +116,11 @@ func ConstructEnvForApp(ctx context.Context, app *spinv1alpha1.SpinApp) []corev1
 		}
 		envs[idx] = env
 	}
+
+	envs = append(envs, corev1.EnvVar{
+		Name:  "SPIN_HTTP_LISTEN_ADDR",
+		Value: fmt.Sprintf("0.0.0.0:%d", listenPort),
+	})
 
 	return envs
 }

--- a/internal/controller/deployment_test.go
+++ b/internal/controller/deployment_test.go
@@ -142,7 +142,7 @@ func TestConstructEnvForApp(t *testing.T) {
 				},
 			}
 
-			envs := ConstructEnvForApp(context.Background(), app)
+			envs := ConstructEnvForApp(context.Background(), app, 0)
 
 			require.Equal(t, test.expectedEnvName, envs[0].Name)
 			require.Equal(t, test.value, envs[0].Value)

--- a/internal/controller/spinapp_controller.go
+++ b/internal/controller/spinapp_controller.go
@@ -423,7 +423,7 @@ func constructDeployment(ctx context.Context, app *spinv1alpha1.SpinApp, config 
 		Requests: app.Spec.Resources.Requests,
 	}
 
-	env := ConstructEnvForApp(ctx, app)
+	env := ConstructEnvForApp(ctx, app, spinapp.DefaultHTTPPort)
 
 	readinessProbe, livenessProbe, err := ConstructPodHealthChecks(app)
 	if err != nil {


### PR DESCRIPTION
This is currently a "practical no-op", as we default to setting the value to the Spin Default.

It does however simplify a future, bigger, change to allow non-80 listen addresses with the container to reduce the priviliges that we give to the shim (e.g runAsNonRoot).