### PR TITLE
maintainers: Add Rajat Jindal

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 
 # These owners will be the default owners for everything in the repository. Unless a later match takes precedence, they
 # will be requested for review when someone opens a pull request.
-*  @calebschoepp @endocrimes @bacongobbler @michelleN
+*  @calebschoepp @endocrimes @bacongobbler @michelleN @rajatjindal


### PR DESCRIPTION
Rajat has been instrumental in the development of the Spin Operator and after discussion amongst the existing maintainers we would like to offer an invitation to join the core maintainer team.

Welcome @rajatjindal :tada:

(After Rajat approves this PR I'll add him to the GitHub team before merging, which will un-break the CODEOWNERS linter)