### PR TITLE
Add support for devcontainers

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,37 @@
+{
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"features": {
+		"ghcr.io/devcontainers/features/go:1": {
+			"version": "1.23.0"
+		},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+			"version": "latest",
+			"helm": "latest",
+			"minikube": "none"
+		}
+	},
+	"containerEnv": {
+		"E2E_USE_NATIVE_SNAPSHOTTER": "true"
+	},
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"go.toolsManagement.checkForUpdates": "local",
+				"go.useLanguageServer": true,
+				"go.gopath": "/go"
+			},
+			"extensions": [
+				"golang.Go",
+				"DavidAnson.vscode-markdownlint"
+			]
+		}
+	},
+	// Allow Debuggers to work
+	"capAdd": [
+		"SYS_PTRACE"
+	],
+	"securityOpt": [
+		"seccomp=unconfined"
+	]
+}

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -race $(go list ./... | grep -v e2e) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -race $(shell go list ./... | grep -v e2e) -coverprofile cover.out
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.54.2

--- a/e2e/k3d_provider.go
+++ b/e2e/k3d_provider.go
@@ -35,6 +35,9 @@ func (c *Cluster) Create(context.Context, string) (string, error) {
 	}
 
 	command := fmt.Sprintf("%s cluster create %s --image %s -p '8081:80@loadbalancer' --agents 2 --wait", k3dBin, c.name, k3dImage)
+	if useNativeSnapshotter() {
+		command = command + ` --k3s-arg "--snapshotter=native@agent:0,1;server:0"`
+	}
 	klog.V(4).Info("Launching:", command)
 	p := utils.RunCommand(command)
 	if p.Err() != nil {
@@ -120,4 +123,8 @@ func clusterExists(name string) (string, bool) {
 		}
 	}
 	return clusters, false
+}
+
+func useNativeSnapshotter() bool {
+	return os.Getenv("E2E_USE_NATIVE_SNAPSHOTTER") == "true"
 }

--- a/e2e/k3d_provider.go
+++ b/e2e/k3d_provider.go
@@ -126,5 +126,5 @@ func clusterExists(name string) (string, bool) {
 }
 
 func useNativeSnapshotter() bool {
-	return os.Getenv("E2E_USE_NATIVE_SNAPSHOTTER") == "true"
+	return os.Getenv("E2E_USE_NATIVE_SNAPSHOTTER") == "true" // nolint:forbidigo
 }


### PR DESCRIPTION
I've been experimenting with devcontainers lately after moving more of my personal compute infra to kubernetes - and trying to have smaller environments.

This is a wip devcontainer setup for spinkube that allows you to also successfully run e2e's without overly complex requirements around systemd hierarchies or having _docker_ on the host itself for dind.

Primarily tested with [DevPod](devpod.sh) backed by Kubernetes, but _should_ work with most container hosts.