### PR TITLE
ca-secrets: Annotate secrets that are created by spin-operator

### DIFF
--- a/internal/controller/spinapp_controller.go
+++ b/internal/controller/spinapp_controller.go
@@ -238,6 +238,9 @@ func (r *SpinAppReconciler) ensureCASecret(ctx context.Context, caSecretName, na
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      caSecretName,
 			Namespace: namespace,
+			Annotations: map[string]string{
+				"app.kubernetes.io/managed-by": "spin-operator.spinkube.dev",
+			},
 		},
 		StringData: map[string]string{"ca-certificates.crt": cacerts.CACertificates()},
 	}


### PR DESCRIPTION
Eventually we will want to upgrade caBundles to new versions as certificates expire/are rotated/new ca's form. We should however only do that when we manage the resource that is created.

Here we introduce a managed-by annotation that we can use to ensure that we don't replace user-managed secret bundles in the future.