### PR TITLE
e2e: speed up

### DIFF
--- a/e2e/default_test.go
+++ b/e2e/default_test.go
@@ -8,7 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/klient"
-	"sigs.k8s.io/e2e-framework/klient/k8s"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
@@ -29,49 +28,28 @@ func TestDefaultSetup(t *testing.T) {
 
 	defaultTest := features.New("default and most minimal setup").
 		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-
 			client = cfg.Client()
 
-			if err := spinapps_v1alpha1.AddToScheme(client.Resources(testNamespace).GetScheme()); err != nil {
-				t.Fatalf("failed to register the spinapps_v1alpha1 types with Kuberenets scheme: %s", err)
-			}
-
-			return ctx
-		}).
-		Assess("spin app custom resource is created", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			testSpinApp := newSpinAppCR(testSpinAppName, helloWorldImage)
-
-			if err := client.Resources().Create(ctx, newContainerdShimExecutor(testNamespace)); err != nil {
-				t.Fatalf("Failed to create spinappexecutor: %s", err)
-			}
-
 			if err := client.Resources().Create(ctx, testSpinApp); err != nil {
 				t.Fatalf("Failed to create spinapp: %s", err)
 			}
-			// wait for spinapp to be created
-			if err := wait.For(
-				conditions.New(client.Resources()).ResourceMatch(testSpinApp, func(object k8s.Object) bool {
-					return true
-				}),
-				wait.WithTimeout(3*time.Minute),
-				wait.WithInterval(30*time.Second),
-			); err != nil {
-				t.Fatal(err)
-			}
 
 			return ctx
 		}).
-		Assess("spin app deployment and service are available", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("spin app deployment is created and available",
+			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				if err := wait.For(
+					conditions.New(client.Resources()).DeploymentAvailable(testSpinAppName, testNamespace),
+					wait.WithTimeout(3*time.Minute),
+					wait.WithInterval(time.Second),
+				); err != nil {
+					t.Fatal(err)
+				}
 
-			// wait for deployment to be ready
-			if err := wait.For(
-				conditions.New(client.Resources()).DeploymentAvailable(testSpinAppName, testNamespace),
-				wait.WithTimeout(3*time.Minute),
-				wait.WithInterval(30*time.Second),
-			); err != nil {
-				t.Fatal(err)
-			}
-
+				return ctx
+			}).
+		Assess("spin app service is created and available", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			svc := &corev1.ServiceList{
 				Items: []corev1.Service{
 					{ObjectMeta: metav1.ObjectMeta{Name: testSpinAppName, Namespace: testNamespace}},
@@ -81,7 +59,7 @@ func TestDefaultSetup(t *testing.T) {
 			if err := wait.For(
 				conditions.New(client.Resources()).ResourcesFound(svc),
 				wait.WithTimeout(3*time.Minute),
-				wait.WithInterval(30*time.Second),
+				wait.WithInterval(time.Second),
 			); err != nil {
 				t.Fatal(err)
 			}
@@ -101,23 +79,6 @@ func newSpinAppCR(name, image string) *spinapps_v1alpha1.SpinApp {
 			Replicas: 1,
 			Image:    image,
 			Executor: "containerd-shim-spin",
-		},
-	}
-}
-
-func newContainerdShimExecutor(namespace string) *spinapps_v1alpha1.SpinAppExecutor {
-	return &spinapps_v1alpha1.SpinAppExecutor{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "containerd-shim-spin",
-			Namespace: namespace,
-		},
-		Spec: spinapps_v1alpha1.SpinAppExecutorSpec{
-			CreateDeployment: true,
-			DeploymentConfig: &spinapps_v1alpha1.ExecutorDeploymentConfig{
-				RuntimeClassName:      runtimeClassName,
-				InstallDefaultCACerts: true,
-				CACertSecret:          testCACertSecret,
-			},
 		},
 	}
 }


### PR DESCRIPTION
While working on adding a new e2e to exercise runtimeConfig options, I realized that our E2Es are slow partially because we have extended intervals for `wait` events - at 30s. This is unfortunate as _the first check_ isn't even called for that 30s period, and meant that the no-op "wait for object to exist" also took 30s.

This speeds up e2es by removing extra `wait`s, and reducing intervals to allow tests to make progress faster when not blocked on a slow network/very slow cpus, without making things _worse_ in those cases.

We also move creating the executor into the test setup, as it's required for all tests, and we don't currently do per-test namespaces.