### PR TITLE
helm: fix generated chart RBAC

### DIFF
--- a/charts/spin-operator/templates/manager-rbac.yaml
+++ b/charts/spin-operator/templates/manager-rbac.yaml
@@ -48,6 +48,13 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - core.spinoperator.dev
   resources:
   - spinappexecutors


### PR DESCRIPTION
After we updated the operator RBAC to include Events, we never updated the checked in version of the chart to reflect that.

This doesn't effect releases, as CI regenerates the helm chart, but does impact people who checkout the repository and use the local helm chart.