### PR TITLE
ref(Dockerfile): Fix linting issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM --platform=${TARGETPLATFORM} gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/bin/manager .
 USER 65532:65532


### PR DESCRIPTION
I'm tired of seeing warnings for [this](https://docs.docker.com/reference/build-checks/redundant-target-platform/).